### PR TITLE
Block on click navigations to increase test reliability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     shimmer (0.1.0)
-      andrewhao-chrome_remote (~> 0.2.0)
+      andrewhao-chrome_remote (~> 0.2.1)
       capybara (~> 2.16)
       nokogiri (~> 1.8.1)
 
@@ -11,7 +11,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    andrewhao-chrome_remote (0.2.0)
+    andrewhao-chrome_remote (0.2.1)
       hashie (~> 3.5)
       websocket-driver (~> 0.6)
     ast (2.3.0)

--- a/lib/shimmer/node.rb
+++ b/lib/shimmer/node.rb
@@ -26,6 +26,8 @@ module Capybara
       def click
         scroll_into_view_if_needed!
         mouse_driver.click(self)
+
+        maybe_block_until_network_request_finishes!
       end
 
       def set(value)
@@ -86,6 +88,14 @@ module Capybara
       end
 
       private
+
+      def maybe_block_until_network_request_finishes!
+        begin
+          browser.wait_for("Network.requestWillBeSent", timeout: 0.1)
+          browser.wait_for("Network.loadingFinished", timeout: 5)
+        rescue Timeout::Error
+        end
+      end
 
       def box_model
         @box_model ||= browser.send_cmd("DOM.getBoxModel", backendNodeId: devtools_backend_node_id).model

--- a/shimmer.gemspec
+++ b/shimmer.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "capybara", "~> 2.16"
   spec.add_dependency "nokogiri", "~> 1.8.1"
-  spec.add_dependency "andrewhao-chrome_remote", "~> 0.2.0"
+  spec.add_dependency "andrewhao-chrome_remote", "~> 0.2.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Add a lightweight blocking routing for user actions that may trigger page navigation.

Problem
---

When Capybara clicks on an element, it immediately proceeds to the next
test assertion without actually pausing to wait for the browser to
transition to the next page.

This causes tests to become flakier because many of them are written
like this:

click_on "link on page 1"
click_on "link on page 2"
expect(page).to have_content("page 3 content")

Whereas we can add implicit wait assertions in between the first two
clicks, it is far easier to have the framework do this for us and block
if it knows the browser is transitioning.

Solution
---

The browser is to check after 100ms of clicking on an element whether it
is scheduled to transition to a new page. If not, it yields execution
back to the test context. If it is scheduled to transition, it waits for
the page to load before yielding.