### PR TITLE
Add a proper visibility detection method on the node

### DIFF
--- a/benchmark/fixtures/index.html
+++ b/benchmark/fixtures/index.html
@@ -50,6 +50,11 @@
 
 <body id="css-zen-garden">
 <div class="page-wrapper">
+  <div id="shimmer-test-custom">
+    <div style="display: none">
+      <p class="should-be-hidden">Should be hidden</p>
+    </div>
+  </div>
 
 	<section class="intro" id="zen-intro">
 		<header role="banner">

--- a/lib/shimmer/javascript_bridge.rb
+++ b/lib/shimmer/javascript_bridge.rb
@@ -20,7 +20,7 @@ module Capybara
                                   returnByValue: false)
         if result.exceptionDetails
           raise JavascriptEvaluationError, result.exceptionDetails.exception
-        elsif result.result.value
+        elsif !result.result.value.nil?
           result.result.value
         else
           result.result

--- a/lib/shimmer/node.rb
+++ b/lib/shimmer/node.rb
@@ -87,14 +87,24 @@ module Capybara
         Capybara::Shimmer::Finder.new(browser).scoped_find_xpath(query, scope: self)
       end
 
+      def visible?
+        javascript_bridge.evaluate_js("
+        function() {
+          const style = window.getComputedStyle(this);
+          const boundingBox = this.getBoundingClientRect();
+          const isComputedStyleVisible = style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0';
+          const isBoundingBoxZero = boundingBox.height === 0 || boundingBox.width === 0;
+          return !isBoundingBoxZero && isComputedStyleVisible;
+       }
+                                      ")
+      end
+
       private
 
       def maybe_block_until_network_request_finishes!
-        begin
-          browser.wait_for("Network.requestWillBeSent", timeout: 0.1)
-          browser.wait_for("Network.loadingFinished", timeout: 5)
-        rescue Timeout::Error
-        end
+        browser.wait_for("Network.requestWillBeSent", timeout: 0.1)
+        browser.wait_for("Network.loadingFinished", timeout: 5)
+      rescue Timeout::Error
       end
 
       def box_model

--- a/spec/features/querying_elements_spec.rb
+++ b/spec/features/querying_elements_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe "querying elements", type: :feature do
       result = find(:link_or_button, "CSS Resource Guide")
       expect(result.text).to eq "CSS Resource Guide"
     end
+
+    it "does not find elements that are hidden" do
+      expect {
+        find('.should-be-hidden')
+      }.to raise_error(Capybara::ElementNotFound)
+    end
   end
 
   describe "#all" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ require_relative "../benchmark/fixture_server"
 fixture_server = FixtureServer.new
 
 Capybara.register_driver :shimmer do |app|
-  Capybara::Shimmer::Driver.new(app, use_proxy: true, headless: false)
+  Capybara::Shimmer::Driver.new(app, use_proxy: false, headless: true)
 end
 
 Capybara.register_driver :headless_chrome do |app|
@@ -25,6 +25,8 @@ Capybara.register_driver :headless_chrome do |app|
   )
 end
 
+# Capybara.current_driver = :headless_chrome
+# Capybara.default_driver = :headless_chrome
 # Capybara.current_driver = :poltergeist
 # Capybara.default_driver = :poltergeist
 Capybara.current_driver = :shimmer


### PR DESCRIPTION
### Problem

Shimmer has a very naive version of detecting visibility that it inherited from `RackTest::Node` where it XPath searches its ancestors in the DOM tree to see if `display: none` appears in anything prior.

### Solution

Visibility is calculated on the browser in the JS context, checking both the [computed style](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) of the immediate note, but also checking its [bounding rect](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) to see whether width/height are zero and hence invisible.