### PR TITLE
Fix Page.navigate navigation bug

### DIFF
--- a/lib/shimmer/browser.rb
+++ b/lib/shimmer/browser.rb
@@ -47,9 +47,10 @@ module Capybara
       def visit(path)
         client.send_cmd "Page.navigate", url: path
         client.wait_for do |event_name, event_params|
-          (event_name == "Page.lifecycleEvent" &&
-            (event_params["name"] == "load" ||
-              event_params["name"] == "networkIdle"))
+          (event_name == "Page.loadEventFired") ||
+            (event_name == "Page.lifecycleEvent" &&
+              (event_params["name"] == "load" ||
+                event_params["name"] == "networkIdle"))
         end
       end
 


### PR DESCRIPTION
Problem
---

Browser stopped navigating to pages. This is due to our code that
instructs the browser to block until the `Page.lifecycleEvent` event
fires back over the socket.

This event suddenly stopped firing on my local Chrome (build 64.0.3282.119)

Solution
---

Turns out there is another (similar) event, called
`Page.loadEventFired`. Also listen to that event, too.