### PR TITLE
Shimmer/Linux compatibility; run tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+# Ruby CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-ruby/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+       - image: circleci/ruby:2.5.0-node-browsers
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+        
+      # Database setup
+      # - run: bundle exec rake db:create
+      # - run: bundle exec rake db:schema:load
+
+      # run tests!
+      - run:
+          name: run tests
+          command: rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   TargetRubyVersion: 2.4
   Exclude:
     - "tmp/**/*"
+    - "vendor/bundle/**/*"
 
 Rails:
   Enabled: false

--- a/benchmark/benchmark
+++ b/benchmark/benchmark
@@ -38,10 +38,9 @@ end
 
 require_relative("./register_capybara_drivers")
 
-
 # Temporary Hashie complaint workaround until we subclass Mash
 # https://github.com/elastic/elasticsearch-rails/issues/666
-Hashie.logger = Logger.new('/dev/null')
+Hashie.logger = Logger.new("/dev/null")
 
 Benchmark.ips do |x|
   x.warmup = 10

--- a/lib/shimmer/browser.rb
+++ b/lib/shimmer/browser.rb
@@ -7,7 +7,7 @@ module Capybara
 
       DEVTOOLS_PORT = 9222
       DEVTOOLS_PROXY_PORT = 9223
-      DEVTOOLS_HOST = "localhost"
+      DEVTOOLS_HOST = "127.0.0.1"
       DEFAULT_WINDOW_WIDTH = 1920
       DEFAULT_WINDOW_HEIGHT = 1080
 

--- a/lib/shimmer/launcher.rb
+++ b/lib/shimmer/launcher.rb
@@ -18,7 +18,7 @@ module Capybara
       def start
         make_directories!
 
-        process_command = "'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' #{launcher_args.join(" ")}"
+        process_command = "'#{executable_path}' #{launcher_args.join(" ")}"
         @browser_pid = Process.spawn process_command, %i[out err] => "log/chrome.#{Time.now.to_f}.log"
         puts
         puts process_command
@@ -95,6 +95,15 @@ module Capybara
 
       def kill!
         Process.kill "INT", @browser_pid
+      end
+
+      # We currently only support Linux and Mac OSX
+      def executable_path
+        if RUBY_PLATFORM.match?(/darwin/)
+          "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        else
+          "google-chrome-stable"
+        end
       end
 
       def register_shutdown_hook!


### PR DESCRIPTION
### Problem

Shimmer was currently runnable only on Mac environments. This prevented us from running it in CI, and also prevents apps from using it on their own CI systems.

### Solution

Assume the existence of a `google-chrome-stable` binary in the path (as Circle CI does).

This allows us to execute Google Chrome from the Linux-based launcher, and also unlocks tests for test frameworks that use CircleCI.