### PR TITLE
Fix a click navigation timeout rescue block error

### DIFF
--- a/benchmark/fixtures/deferred_page_render.html
+++ b/benchmark/fixtures/deferred_page_render.html
@@ -1,0 +1,14 @@
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+</head>
+<body id="fixture-deferred-page-render">
+  <div id="app">
+  </div>
+  <script>
+    setTimeout(function() {
+      document.querySelector("#app").innerHTML = "<p>New Page Content</p>";
+    }, 1000)
+  </script>
+</body>
+</html>

--- a/benchmark/fixtures/mouse.html
+++ b/benchmark/fixtures/mouse.html
@@ -12,6 +12,14 @@
 
 <body>
   <a class="mouse-hover-target" href="/">Hover Me</a>
+  <div class="mouse-click-target">Click Me</div>
+
+  <script>
+    document.querySelector('.mouse-click-target')
+      .addEventListener('click', function(e) {
+        e.target.innerHTML = "Clicked!"
+      });
+  </script>
 </body>
 
 </html>

--- a/lib/shimmer/driver.rb
+++ b/lib/shimmer/driver.rb
@@ -10,10 +10,10 @@ module Capybara
 
       def initialize(app, options = {})
         supplied_browser = options.delete(:browser)
+        @logger  = Logger.new(STDOUT)
         @options = options.dup
         @browser = supplied_browser || Capybara::Shimmer::Browser.new(@options).start
         @app     = app
-        @logger  = Logger.new(STDOUT)
       end
 
       def_delegators :browser, :current_url, :visit, :html,

--- a/lib/shimmer/node.rb
+++ b/lib/shimmer/node.rb
@@ -6,7 +6,7 @@
 module Capybara
   module Shimmer
     class Node < Capybara::RackTest::Node
-      attr_reader :devtools_node_id, :devtools_backend_node_id, :devtools_remote_object_id
+      attr_reader :devtools_node_id, :devtools_backend_node_id, :devtools_remote_object_id, :logger
 
       def initialize(driver,
                      native,
@@ -17,6 +17,7 @@ module Capybara
         @devtools_node_id = devtools_node_id
         @devtools_backend_node_id = devtools_backend_node_id
         @devtools_remote_object_id = devtools_remote_object_id
+        @logger = Logger.new(STDOUT)
       end
 
       def value
@@ -114,7 +115,7 @@ function() {
         browser.wait_for("Network.requestWillBeSent", timeout: 0.1)
         browser.wait_for("Network.loadingFinished", timeout: 5)
       rescue Timeout::Error => _e
-        driver.logger.debug "No network event processed - continuing."
+        logger.debug "No network event processed - continuing."
       end
 
       def box_model

--- a/lib/shimmer/node.rb
+++ b/lib/shimmer/node.rb
@@ -24,6 +24,14 @@ module Capybara
         javascript_bridge.evaluate_js("function() { return this.value }")
       end
 
+      def all_text
+        Capybara::Helpers.normalize_whitespace(javascript_bridge.evaluate_js("function() { return this.textContent }"))
+      end
+
+      def visible_text
+        visible? ? all_text : ""
+      end
+
       def click
         scroll_into_view_if_needed!
         mouse_driver.click(self)

--- a/spec/features/matcher_spec.rb
+++ b/spec/features/matcher_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe "RSpec matcher DSL", type: :feature do
+  before do
+  end
+
+  describe "#has_content?" do
+    it "matches with page text" do
+      visit "/index.html"
+      expect(page).to have_content("CSS Zen Garden")
+    end
+
+    it "finds text that is deferred" do
+      visit "/deferred_page_render.html"
+      Capybara.using_wait_time 2 do
+        expect(page).to have_content("New Page Content")
+      end
+    end
+
+    it "finds text with manual override" do
+      visit "/deferred_page_render.html"
+      expect(page).to have_content("New Page Content", wait: 4)
+    end
+  end
+end

--- a/spec/features/mouse_actions_spec.rb
+++ b/spec/features/mouse_actions_spec.rb
@@ -11,5 +11,11 @@ RSpec.describe "mouse actions", type: :feature do
       find(".mouse-hover-target").hover
       expect(page).to have_selector(".mouse-hover-target:hover")
     end
+
+    it "clicks on an element" do
+      click_target = find(".mouse-click-target")
+      click_target.click
+      expect(click_target.text).to eq "Clicked!"
+    end
   end
 end

--- a/spec/features/querying_elements_spec.rb
+++ b/spec/features/querying_elements_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe "querying elements", type: :feature do
         find(".should-be-hidden")
       }.to raise_error(Capybara::ElementNotFound)
     end
+
+    it "does not reveal text if the element is hidden" do
+      hidden = find(".should-be-hidden", visible: false)
+      expect(hidden.text).to eq ""
+    end
   end
 
   describe "#all" do

--- a/spec/shimmer/node_spec.rb
+++ b/spec/shimmer/node_spec.rb
@@ -57,4 +57,18 @@ RSpec.describe Capybara::Shimmer::Node do
       subject.click
     end
   end
+
+  describe "#all_text" do
+    it "delegates out to the JavascriptBridge" do
+      expect(javascript_bridge).to receive(:evaluate_js)
+        .and_return("Some Text")
+      expect(subject.all_text).to eq "Some Text"
+    end
+
+    it "normalizes whitespace" do
+      expect(javascript_bridge).to receive(:evaluate_js)
+        .and_return("Some    \n    Text")
+      expect(subject.all_text).to eq "Some Text"
+    end
+  end
 end

--- a/spec/shimmer/node_spec.rb
+++ b/spec/shimmer/node_spec.rb
@@ -43,4 +43,18 @@ RSpec.describe Capybara::Shimmer::Node do
         .with(subject)
     end
   end
+
+  describe "#click" do
+    it "fires a click on the mouse" do
+      expect(mouse_driver).to receive(:click)
+      expect(browser).to receive(:wait_for).at_least(2).times
+      subject.click
+    end
+
+    it "rescues from a TimeoutError" do
+      expect(mouse_driver).to receive(:click)
+      expect(browser).to receive(:wait_for).and_raise(Timeout::Error)
+      subject.click
+    end
+  end
 end


### PR DESCRIPTION
Instead of inferring a reference to a Logger object, the Node should just instantiate its own.

Additionally, we add a feature where a `Node`'s text attributes are always re-queried if the caller asks for them.