### PR TITLE
Do not reveal text that is actually hidden [#18]

### DIFF
--- a/benchmark/fixtures/script_tags.html
+++ b/benchmark/fixtures/script_tags.html
@@ -1,0 +1,12 @@
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+</head>
+<body id="fixture-deferred-page-render">
+  <div id="app">
+  </div>
+  <script>
+    var foo = "This text is in a script tag";
+  </script>
+</body>
+</html>

--- a/lib/shimmer/node.rb
+++ b/lib/shimmer/node.rb
@@ -29,7 +29,7 @@ module Capybara
       end
 
       def visible_text
-        visible? ? all_text : ""
+        visible? ? inner_text : ""
       end
 
       def click
@@ -118,6 +118,10 @@ function() {
       end
 
       private
+
+      def inner_text
+        javascript_bridge.evaluate_js("function() { return this.innerText }")
+      end
 
       def maybe_block_until_network_request_finishes!
         browser.wait_for("Network.requestWillBeSent", timeout: 0.1)

--- a/spec/features/matcher_spec.rb
+++ b/spec/features/matcher_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe "RSpec matcher DSL", type: :feature do
   end
 
   describe "#has_content?" do
+    it "does not return text in script tags" do
+      visit "/script_tags.html"
+      expect(page).to_not have_content("This text is in a script tag")
+    end
+
     it "matches with page text" do
       visit "/index.html"
       expect(page).to have_content("CSS Zen Garden")
@@ -12,7 +17,7 @@ RSpec.describe "RSpec matcher DSL", type: :feature do
 
     it "finds text that is deferred" do
       visit "/deferred_page_render.html"
-      Capybara.using_wait_time 2 do
+      Capybara.using_wait_time 5 do
         expect(page).to have_content("New Page Content")
       end
     end

--- a/spec/features/querying_elements_spec.rb
+++ b/spec/features/querying_elements_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe "querying elements", type: :feature do
       hidden = find(".should-be-hidden", visible: false)
       expect(hidden.text).to eq ""
     end
+
+    context "textual content" do
+      it "returns nested text" do
+        body = find("#design-selection nav")
+        expect(body.text).to include "Mid Century Modern by Andrew Lohman"
+      end
+
+      it "does not return text in script tags" do
+        visit "/script_tags.html"
+        body = find("body")
+        expect(body.text).to eq ""
+      end
+
+      it "does not display text in hidden elements" do
+        body = find("body")
+        expect(body.text).to_not include "Should be hidden"
+      end
+    end
   end
 
   describe "#all" do


### PR DESCRIPTION
Previously, we would lean on `Node.textContent` to reveal a node's textual
content. However, this renders literally every text node within a DOM
node, which does not take hidden elements (like hidden DIVs or script
tags into account).

Instead, we lean on `Node.innerText`, which according to the docs
"represents the rendered text content of a node and its descendants":

https://developer.mozilla.org/en-US/docs/Web/API/Node/innerText

Issue #18 