### PR TITLE
Also remember to normalize/strip whitespaces in text query [#18]

### DIFF
--- a/lib/shimmer.rb
+++ b/lib/shimmer.rb
@@ -8,6 +8,7 @@ require "shimmer/keyboard_driver"
 require "shimmer/mouse_driver"
 require "shimmer/javascript_bridge"
 require "shimmer/javascript_evaluation_error"
+require "shimmer/javascript_expressions"
 
 module Shimmer
 end

--- a/lib/shimmer/javascript_expressions.rb
+++ b/lib/shimmer/javascript_expressions.rb
@@ -1,0 +1,25 @@
+module Capybara
+  module Shimmer
+    module JavascriptExpressions
+      NODE_VISIBLE = "
+function() {
+  let element = this;
+  while (element) {
+    const style = window.getComputedStyle(element);
+    const isComputedStyleVisible =
+      style &&
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      style.opacity !== '0';
+    if (!isComputedStyleVisible) {
+      return false;
+    }
+    element = element.parentElement;
+  }
+  return true;
+}
+                                      "
+      INNER_TEXT = "function() { return this.innerText }"
+    end
+  end
+end

--- a/lib/shimmer/node.rb
+++ b/lib/shimmer/node.rb
@@ -25,11 +25,13 @@ module Capybara
       end
 
       def all_text
-        Capybara::Helpers.normalize_whitespace(javascript_bridge.evaluate_js("function() { return this.textContent }"))
+        text = javascript_bridge.evaluate_js("function() { return this.textContent }")
+        Capybara::Helpers.normalize_whitespace(text)
       end
 
       def visible_text
-        visible? ? inner_text : ""
+        text = visible? ? inner_text : ""
+        Capybara::Helpers.normalize_whitespace(text)
       end
 
       def click
@@ -97,30 +99,13 @@ module Capybara
       end
 
       def visible?
-        javascript_bridge.evaluate_js("
-function() {
-  let element = this;
-  while (element) {
-    const style = window.getComputedStyle(element);
-    const isComputedStyleVisible =
-      style &&
-      style.display !== 'none' &&
-      style.visibility !== 'hidden' &&
-      style.opacity !== '0';
-    if (!isComputedStyleVisible) {
-      return false;
-    }
-    element = element.parentElement;
-  }
-  return true;
-}
-                                      ")
+        javascript_bridge.evaluate_js(Capybara::Shimmer::JavascriptExpressions::NODE_VISIBLE)
       end
 
       private
 
       def inner_text
-        javascript_bridge.evaluate_js("function() { return this.innerText }")
+        javascript_bridge.evaluate_js(Capybara::Shimmer::JavascriptExpressions::INNER_TEXT)
       end
 
       def maybe_block_until_network_request_finishes!

--- a/spec/shimmer/node_spec.rb
+++ b/spec/shimmer/node_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe Capybara::Shimmer::Node do
     end
   end
 
+  describe "#visible_text" do
+    it "delegates out to the JavascriptBridge" do
+      expect(javascript_bridge).to receive(:evaluate_js)
+        .with(Capybara::Shimmer::JavascriptExpressions::NODE_VISIBLE)
+        .and_return(true)
+      expect(javascript_bridge).to receive(:evaluate_js)
+        .with(Capybara::Shimmer::JavascriptExpressions::INNER_TEXT)
+        .and_return("Some Text")
+      expect(subject.visible_text).to eq "Some Text"
+    end
+
+    it "normalizes whitespace" do
+      allow(javascript_bridge).to receive(:evaluate_js)
+        .with(Capybara::Shimmer::JavascriptExpressions::NODE_VISIBLE)
+        .and_return(true)
+      expect(javascript_bridge).to receive(:evaluate_js)
+        .with(Capybara::Shimmer::JavascriptExpressions::INNER_TEXT)
+        .and_return("Some    \n    Text")
+      expect(subject.visible_text).to eq "Some Text"
+    end
+  end
+
   describe "#all_text" do
     it "delegates out to the JavascriptBridge" do
       expect(javascript_bridge).to receive(:evaluate_js)


### PR DESCRIPTION
Fully fixes #18

We neglected to run the output of the text query through `Capybara::Helpers.normalize_whitespace`